### PR TITLE
Add GitHub Actions workflow to label new issues

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,60 @@
+name: Label new issues with GSSoC
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-gssoc-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Ensure label and add to issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            
+            const label = 'NSoC'26';
+            const color = 'C0F486'; 
+            const description = 'Under Nexus Spring of Code';
+            
+            try {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label,
+                new_name: label,
+                color,
+                description
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color,
+                    description
+                  });
+                } catch (createErr) {
+                  if (createErr.status !== 422) {
+                    throw createErr;
+                  }
+                }
+              } else {
+                throw err;
+              }
+            }
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label]
+            });


### PR DESCRIPTION
### Description
Adds a GitHub Actions workflow to automatically apply the NSoC'26 label whenever a new issue is opened.
The workflow also creates the label if it does not already exist.

###  Related Issue
Closes #31 

### Changes
Added workflow: .github/workflows/auto-label-nsoc-issues.yml
Trigger: issues opened
Added logic to create NSoC'26 label if missing
Added logic to apply NSoC'26 label to each new issue
