### PR TITLE
added issue templates & updated contribution.md file (only the part which showed how to create an issue)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Report a reproducible problem in the repository.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+        Please fill out the form with enough detail for maintainers to reproduce and triage the issue.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-Submission Checks
+      description: Confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and confirmed this bug has not been reported already.
+          required: true
+        - label: I am willing to work on this issue if needed.
+          required: false
+
+  - type: dropdown
+    id: contribution_program
+    attributes:
+      label: Contribution Program
+      description: Select the program you are contributing under.
+      options:
+        - General / Not part of a contribution program
+        - GSSoC 2026
+        - NSoC 2026
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty Level
+      description: Estimate the difficulty of fixing this issue.
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: Describe what is happening right now.
+      placeholder: The page crashes when I click...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Share the exact steps needed to reproduce the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen instead.
+      placeholder: The page should...
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Add any relevant environment details.
+      placeholder: Windows 11, Chrome 136, mobile viewport
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or References
+      description: Paste screenshot links or any references that help explain the issue.
+      placeholder: Add screenshot links, console output, or related references here.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Share anything else that would help triage this bug.
+      placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,10 +8,18 @@ body:
         Thanks for reporting a bug.
         Please fill out the form with enough detail for maintainers to reproduce and triage the issue.
 
+  - type: markdown
+    attributes:
+      value: |
+        **Formatting note**
+        Do not use markdown headings such as `#`, `##`, or `###` inside any response box.
+        These fields already render with headings in the final issue.
+        Use plain text, bullet points (-), or numbered lists instead(1., 2., 3.).
+
   - type: checkboxes
     id: checks
     attributes:
-      label: Pre-Submission Checks
+      label: "[ISSUE FORM] Pre-Submission Checks"
       description: Confirm the following before submitting.
       options:
         - label: I have searched the existing issues and confirmed this bug has not been reported already.
@@ -22,7 +30,7 @@ body:
   - type: dropdown
     id: contribution_program
     attributes:
-      label: Contribution Program
+      label: "[ISSUE FORM] Contribution Program"
       description: Select the program you are contributing under.
       options:
         - General / Not part of a contribution program
@@ -34,7 +42,7 @@ body:
   - type: dropdown
     id: difficulty
     attributes:
-      label: Difficulty Level
+      label: "[ISSUE FORM] Difficulty Level"
       description: Estimate the difficulty of fixing this issue.
       options:
         - Beginner
@@ -47,7 +55,7 @@ body:
   - type: textarea
     id: current_behavior
     attributes:
-      label: Current Behavior
+      label: "[ISSUE FORM] Current Behavior"
       description: Describe what is happening right now.
       placeholder: The page crashes when I click...
     validations:
@@ -56,7 +64,7 @@ body:
   - type: textarea
     id: steps_to_reproduce
     attributes:
-      label: Steps to Reproduce
+      label: "[ISSUE FORM] Steps to Reproduce"
       description: Share the exact steps needed to reproduce the bug.
       placeholder: |
         1. Go to ...
@@ -68,7 +76,7 @@ body:
   - type: textarea
     id: expected_behavior
     attributes:
-      label: Expected Behavior
+      label: "[ISSUE FORM] Expected Behavior"
       description: Describe what should happen instead.
       placeholder: The page should...
     validations:
@@ -77,20 +85,20 @@ body:
   - type: input
     id: environment
     attributes:
-      label: Environment
+      label: "[ISSUE FORM] Environment"
       description: Add any relevant environment details.
       placeholder: Windows 11, Chrome 136, mobile viewport
 
   - type: textarea
     id: screenshots
     attributes:
-      label: Screenshots or References
+      label: "[ISSUE FORM] Screenshots or References"
       description: Paste screenshot links or any references that help explain the issue.
       placeholder: Add screenshot links, console output, or related references here.
 
   - type: textarea
     id: additional_context
     attributes:
-      label: Additional Context
+      label: "[ISSUE FORM] Additional Context"
       description: Share anything else that would help triage this bug.
       placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,0 +1,86 @@
+name: Documentation Improvement
+description: Suggest improvements to guides, docs, or contributor instructions.
+title: "[Docs]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the documentation.
+        Please point to the gap clearly and describe the change that would make the docs better.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-Submission Checks
+      description: Confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and confirmed this documentation issue has not been raised already.
+          required: true
+        - label: I am willing to work on this issue if needed.
+          required: false
+
+  - type: dropdown
+    id: contribution_program
+    attributes:
+      label: Contribution Program
+      description: Select the program you are contributing under.
+      options:
+        - General / Not part of a contribution program
+        - GSSoC 2026
+        - NSoC 2026
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty Level
+      description: Estimate the difficulty of this documentation update.
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected Area
+      description: Which file, page, or section needs improvement?
+      placeholder: README.md, contributing guide, setup steps...
+    validations:
+      required: true
+
+  - type: textarea
+    id: documentation_gap
+    attributes:
+      label: Problem Description
+      description: What is unclear, missing, outdated, or incorrect?
+      placeholder: The current docs do not explain...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_solution
+    attributes:
+      label: Expected Solution
+      description: Describe the improvement you want to see.
+      placeholder: Add a section that explains...
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References or Supporting Material
+      description: Add related links, screenshots, or examples if they help.
+      placeholder: Related links or references...
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Share anything else maintainers should know.
+      placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -8,10 +8,18 @@ body:
         Thanks for helping improve the documentation.
         Please point to the gap clearly and describe the change that would make the docs better.
 
+  - type: markdown
+    attributes:
+      value: |
+        **Formatting note**
+        Do not use markdown headings such as `#`, `##`, or `###` inside any response box.
+        These fields already render with headings in the final issue.
+        Use plain text, bullet points (-), or numbered lists instead(1., 2., 3.).
+
   - type: checkboxes
     id: checks
     attributes:
-      label: Pre-Submission Checks
+      label: "[ISSUE FORM] Pre-Submission Checks"
       description: Confirm the following before submitting.
       options:
         - label: I have searched the existing issues and confirmed this documentation issue has not been raised already.
@@ -22,7 +30,7 @@ body:
   - type: dropdown
     id: contribution_program
     attributes:
-      label: Contribution Program
+      label: "[ISSUE FORM] Contribution Program"
       description: Select the program you are contributing under.
       options:
         - General / Not part of a contribution program
@@ -34,7 +42,7 @@ body:
   - type: dropdown
     id: difficulty
     attributes:
-      label: Difficulty Level
+      label: "[ISSUE FORM] Difficulty Level"
       description: Estimate the difficulty of this documentation update.
       options:
         - Beginner
@@ -47,7 +55,7 @@ body:
   - type: input
     id: affected_area
     attributes:
-      label: Affected Area
+      label: "[ISSUE FORM] Affected Area"
       description: Which file, page, or section needs improvement?
       placeholder: README.md, contributing guide, setup steps...
     validations:
@@ -56,7 +64,7 @@ body:
   - type: textarea
     id: documentation_gap
     attributes:
-      label: Problem Description
+      label: "[ISSUE FORM] Problem Description"
       description: What is unclear, missing, outdated, or incorrect?
       placeholder: The current docs do not explain...
     validations:
@@ -65,7 +73,7 @@ body:
   - type: textarea
     id: expected_solution
     attributes:
-      label: Expected Solution
+      label: "[ISSUE FORM] Expected Solution"
       description: Describe the improvement you want to see.
       placeholder: Add a section that explains...
     validations:
@@ -74,13 +82,13 @@ body:
   - type: textarea
     id: references
     attributes:
-      label: References or Supporting Material
+      label: "[ISSUE FORM] References or Supporting Material"
       description: Add related links, screenshots, or examples if they help.
       placeholder: Related links or references...
 
   - type: textarea
     id: additional_context
     attributes:
-      label: Additional Context
+      label: "[ISSUE FORM] Additional Context"
       description: Share anything else maintainers should know.
       placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,84 @@
+name: Feature Request
+description: Suggest a new feature or improvement for the repository.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe the problem clearly and explain the outcome you want to see.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-Submission Checks
+      description: Confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and confirmed this request has not been raised already.
+          required: true
+        - label: I am willing to work on this issue if needed.
+          required: false
+
+  - type: dropdown
+    id: contribution_program
+    attributes:
+      label: Contribution Program
+      description: Select the program you are contributing under.
+      options:
+        - General / Not part of a contribution program
+        - GSSoC 2026
+        - NSoC 2026
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty Level
+      description: Estimate the implementation difficulty.
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_description
+    attributes:
+      label: Problem Description
+      description: What problem or limitation are you trying to solve?
+      placeholder: Right now contributors cannot...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_solution
+    attributes:
+      label: Expected Solution
+      description: Describe the solution or behavior you want.
+      placeholder: It would be better if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Mention any other solutions or approaches you considered.
+      placeholder: Optional alternative approaches...
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Mockups, Screenshots, or References
+      description: Add supporting visuals or references if available.
+      placeholder: Add screenshot links, design references, or examples here.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Share anything else that would help evaluate this request.
+      placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,10 +8,18 @@ body:
         Thanks for suggesting an improvement.
         Please describe the problem clearly and explain the outcome you want to see.
 
+  - type: markdown
+    attributes:
+      value: |
+        **Formatting note**
+        Do not use markdown headings such as `#`, `##`, or `###` inside any response box.
+        These fields already render with headings in the final issue.
+        Use plain text, bullet points (-), or numbered lists instead(1., 2., 3.).
+
   - type: checkboxes
     id: checks
     attributes:
-      label: Pre-Submission Checks
+      label: "[ISSUE FORM] Pre-Submission Checks"
       description: Confirm the following before submitting.
       options:
         - label: I have searched the existing issues and confirmed this request has not been raised already.
@@ -22,7 +30,7 @@ body:
   - type: dropdown
     id: contribution_program
     attributes:
-      label: Contribution Program
+      label: "[ISSUE FORM] Contribution Program"
       description: Select the program you are contributing under.
       options:
         - General / Not part of a contribution program
@@ -34,7 +42,7 @@ body:
   - type: dropdown
     id: difficulty
     attributes:
-      label: Difficulty Level
+      label: "[ISSUE FORM] Difficulty Level"
       description: Estimate the implementation difficulty.
       options:
         - Beginner
@@ -47,7 +55,7 @@ body:
   - type: textarea
     id: problem_description
     attributes:
-      label: Problem Description
+      label: "[ISSUE FORM] Problem Description"
       description: What problem or limitation are you trying to solve?
       placeholder: Right now contributors cannot...
     validations:
@@ -56,7 +64,7 @@ body:
   - type: textarea
     id: expected_solution
     attributes:
-      label: Expected Solution
+      label: "[ISSUE FORM] Expected Solution"
       description: Describe the solution or behavior you want.
       placeholder: It would be better if...
     validations:
@@ -65,20 +73,20 @@ body:
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives Considered
+      label: "[ISSUE FORM] Alternatives Considered"
       description: Mention any other solutions or approaches you considered.
       placeholder: Optional alternative approaches...
 
   - type: textarea
     id: screenshots
     attributes:
-      label: Mockups, Screenshots, or References
+      label: "[ISSUE FORM] Mockups, Screenshots, or References"
       description: Add supporting visuals or references if available.
       placeholder: Add screenshot links, design references, or examples here.
 
   - type: textarea
     id: additional_context
     attributes:
-      label: Additional Context
+      label: "[ISSUE FORM] Additional Context"
       description: Share anything else that would help evaluate this request.
       placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/project_task_request.yml
+++ b/.github/ISSUE_TEMPLATE/project_task_request.yml
@@ -1,0 +1,86 @@
+name: Project/Task Request
+description: Propose a new project idea or a structured task for contributors.
+title: "[Task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new project or contributor task.
+        Please describe the task clearly so maintainers can assess its value and scope.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-Submission Checks
+      description: Confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and confirmed this request has not been raised already.
+          required: true
+        - label: I am willing to work on this issue if needed.
+          required: false
+
+  - type: dropdown
+    id: contribution_program
+    attributes:
+      label: Contribution Program
+      description: Select the program you are contributing under.
+      options:
+        - General / Not part of a contribution program
+        - GSSoC 2026
+        - NSoC 2026
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty Level
+      description: Estimate the difficulty of this task or project request.
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: requested_task
+    attributes:
+      label: Requested Project or Task
+      description: Name the project idea or task you want to propose.
+      placeholder: Add a Kanban board app, improve contributor page filters...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_description
+    attributes:
+      label: Problem Description
+      description: What problem does this task or project solve?
+      placeholder: This would help contributors learn...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_solution
+    attributes:
+      label: Expected Solution or Scope
+      description: Describe the expected outcome, deliverables, or boundaries.
+      placeholder: The task should include...
+    validations:
+      required: true
+
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources or References
+      description: Add references, examples, or supporting links if available.
+      placeholder: Reference links, inspiration, or related issues...
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Share anything else that would help maintainers review this request.
+      placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/project_task_request.yml
+++ b/.github/ISSUE_TEMPLATE/project_task_request.yml
@@ -8,10 +8,18 @@ body:
         Thanks for proposing a new project or contributor task.
         Please describe the task clearly so maintainers can assess its value and scope.
 
+  - type: markdown
+    attributes:
+      value: |
+        **Formatting note**
+        Do not use markdown headings such as `#`, `##`, or `###` inside any response box.
+        These fields already render with headings in the final issue.
+        Use plain text, bullet points (-), or numbered lists instead(1., 2., 3.).
+
   - type: checkboxes
     id: checks
     attributes:
-      label: Pre-Submission Checks
+      label: "[ISSUE FORM] Pre-Submission Checks"
       description: Confirm the following before submitting.
       options:
         - label: I have searched the existing issues and confirmed this request has not been raised already.
@@ -22,7 +30,7 @@ body:
   - type: dropdown
     id: contribution_program
     attributes:
-      label: Contribution Program
+      label: "[ISSUE FORM] Contribution Program"
       description: Select the program you are contributing under.
       options:
         - General / Not part of a contribution program
@@ -34,7 +42,7 @@ body:
   - type: dropdown
     id: difficulty
     attributes:
-      label: Difficulty Level
+      label: "[ISSUE FORM] Difficulty Level"
       description: Estimate the difficulty of this task or project request.
       options:
         - Beginner
@@ -47,7 +55,7 @@ body:
   - type: input
     id: requested_task
     attributes:
-      label: Requested Project or Task
+      label: "[ISSUE FORM] Requested Project or Task"
       description: Name the project idea or task you want to propose.
       placeholder: Add a Kanban board app, improve contributor page filters...
     validations:
@@ -56,7 +64,7 @@ body:
   - type: textarea
     id: problem_description
     attributes:
-      label: Problem Description
+      label: "[ISSUE FORM] Problem Description"
       description: What problem does this task or project solve?
       placeholder: This would help contributors learn...
     validations:
@@ -65,7 +73,7 @@ body:
   - type: textarea
     id: expected_solution
     attributes:
-      label: Expected Solution or Scope
+      label: "[ISSUE FORM] Expected Solution or Scope"
       description: Describe the expected outcome, deliverables, or boundaries.
       placeholder: The task should include...
     validations:
@@ -74,13 +82,13 @@ body:
   - type: textarea
     id: resources
     attributes:
-      label: Resources or References
+      label: "[ISSUE FORM] Resources or References"
       description: Add references, examples, or supporting links if available.
       placeholder: Reference links, inspiration, or related issues...
 
   - type: textarea
     id: additional_context
     attributes:
-      label: Additional Context
+      label: "[ISSUE FORM] Additional Context"
       description: Share anything else that would help maintainers review this request.
       placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/ui_ux_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/ui_ux_enhancement.yml
@@ -1,0 +1,86 @@
+name: UI/UX Enhancement
+description: Suggest a user interface or user experience improvement.
+title: "[UI/UX]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a UI or UX improvement.
+        Please describe the current pain point and the improvement you want to see.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-Submission Checks
+      description: Confirm the following before submitting.
+      options:
+        - label: I have searched the existing issues and confirmed this enhancement has not been raised already.
+          required: true
+        - label: I am willing to work on this issue if needed.
+          required: false
+
+  - type: dropdown
+    id: contribution_program
+    attributes:
+      label: Contribution Program
+      description: Select the program you are contributing under.
+      options:
+        - General / Not part of a contribution program
+        - GSSoC 2026
+        - NSoC 2026
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty Level
+      description: Estimate the implementation difficulty.
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected Page or Component
+      description: Which page, section, or component should be improved?
+      placeholder: Navbar, hero section, contributors page...
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_problem
+    attributes:
+      label: Problem Description
+      description: What is the current UI/UX problem?
+      placeholder: The current layout feels crowded because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_solution
+    attributes:
+      label: Expected Solution
+      description: Describe the enhancement you want.
+      placeholder: Improve the spacing, hierarchy, or interaction by...
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots, Mockups, or References
+      description: Add any visuals or references that clarify the request.
+      placeholder: Add screenshot links, design references, or mockups here.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Share anything else maintainers should know.
+      placeholder: Additional details...

--- a/.github/ISSUE_TEMPLATE/ui_ux_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/ui_ux_enhancement.yml
@@ -8,10 +8,18 @@ body:
         Thanks for suggesting a UI or UX improvement.
         Please describe the current pain point and the improvement you want to see.
 
+  - type: markdown
+    attributes:
+      value: |
+        **Formatting note**
+        Do not use markdown headings such as `#`, `##`, or `###` inside any response box.
+        These fields already render with headings in the final issue.
+        Use plain text, bullet points (-), or numbered lists instead(1., 2., 3.).
+
   - type: checkboxes
     id: checks
     attributes:
-      label: Pre-Submission Checks
+      label: "[ISSUE FORM] Pre-Submission Checks"
       description: Confirm the following before submitting.
       options:
         - label: I have searched the existing issues and confirmed this enhancement has not been raised already.
@@ -22,7 +30,7 @@ body:
   - type: dropdown
     id: contribution_program
     attributes:
-      label: Contribution Program
+      label: "[ISSUE FORM] Contribution Program"
       description: Select the program you are contributing under.
       options:
         - General / Not part of a contribution program
@@ -34,7 +42,7 @@ body:
   - type: dropdown
     id: difficulty
     attributes:
-      label: Difficulty Level
+      label: "[ISSUE FORM] Difficulty Level"
       description: Estimate the implementation difficulty.
       options:
         - Beginner
@@ -47,7 +55,7 @@ body:
   - type: input
     id: affected_area
     attributes:
-      label: Affected Page or Component
+      label: "[ISSUE FORM] Affected Page or Component"
       description: Which page, section, or component should be improved?
       placeholder: Navbar, hero section, contributors page...
     validations:
@@ -56,7 +64,7 @@ body:
   - type: textarea
     id: current_problem
     attributes:
-      label: Problem Description
+      label: "[ISSUE FORM] Problem Description"
       description: What is the current UI/UX problem?
       placeholder: The current layout feels crowded because...
     validations:
@@ -65,7 +73,7 @@ body:
   - type: textarea
     id: expected_solution
     attributes:
-      label: Expected Solution
+      label: "[ISSUE FORM] Expected Solution"
       description: Describe the enhancement you want.
       placeholder: Improve the spacing, hierarchy, or interaction by...
     validations:
@@ -74,13 +82,13 @@ body:
   - type: textarea
     id: screenshots
     attributes:
-      label: Screenshots, Mockups, or References
+      label: "[ISSUE FORM] Screenshots, Mockups, or References"
       description: Add any visuals or references that clarify the request.
       placeholder: Add screenshot links, design references, or mockups here.
 
   - type: textarea
     id: additional_context
     attributes:
-      label: Additional Context
+      label: "[ISSUE FORM] Additional Context"
       description: Share anything else maintainers should know.
       placeholder: Additional details...

--- a/contributing.md
+++ b/contributing.md
@@ -216,10 +216,10 @@ chore: update dependencies
 
 If you find a bug or want to suggest a feature:
 
-1. Open an issue.
-2. Provide a clear title and description.
-3. Include screenshots or steps to reproduce.
-4. Mention your environment (browser, OS, device).
+1. Open the matching issue form.
+2. Select your contribution program: `General`, `GSSoC 2026`, or `NSoC 2026`.
+3. Fill in the structured fields with a clear problem statement and expected solution.
+4. Include screenshots, references, reproduction steps, and environment details when relevant.
 
 ---
 


### PR DESCRIPTION
created a `ISSUE_TEMPLATE` folder inside the `.github` folder. Added issue templates in them.
<img width="352" height="246" alt="image" src="https://github.com/user-attachments/assets/bfcaa7ec-32f9-4dea-82c1-f3f09a06e3f3" />

**Here is how it initaily looked**

https://github.com/user-attachments/assets/84cc9a80-24d9-4702-9efd-a2a125f645c6

**realised that users might use `#` `##` `###` which might make the issues content look worse**
tried figureing out something to make headings look better. But,
> apparently we cannot change css styling of github issue form labels. which basically means that you cannot make the headings `<h1>` 

So the only possible option was this : -
<img width="810" height="738" alt="image" src="https://github.com/user-attachments/assets/fa747625-cc97-4cdc-af46-14bd964902bd" />

Here is how the final output would look like (if done right) :-
<img width="862" height="852" alt="image" src="https://github.com/user-attachments/assets/60205a8d-baaf-46e3-a7d1-cf4561488645" />


### PS: 
i though of taking the input in codeblock rather then markdown. But it has its cons as well.
did `git reset` many times while figuring out a better way. but no luck.

### caution 🔴  
This : 
<img width="721" height="68" alt="image" src="https://github.com/user-attachments/assets/23a200fd-092c-4b50-927a-2cb96aba1ea8" />

and this : 
<img width="327" height="37" alt="image" src="https://github.com/user-attachments/assets/eafe90e2-0acf-4847-92ff-698fdd3b39a5" />

**are only visible to the project admin**
obviously (contributors don't decide their labels), but still had to mention in case someone else is also reviewing.

Closes: #48 