### PR TITLE
feat: add Load More pagination to projects grid

### DIFF
--- a/components/project/project-grid.tsx
+++ b/components/project/project-grid.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { projectConfig } from "@/config/projects";
+import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { FaGithub, FaLink, FaSearch, FaYoutube , FaBookmark} from "react-icons/fa";
+import { FaBookmark, FaChevronDown, FaGithub, FaLink, FaSearch, FaYoutube } from "react-icons/fa";
 import SearchBar from "./search-bar";
+
+const PROJECTS_PER_PAGE = 6;
 
 export default function ProjectGrid() {
   const [searchQuery, setSearchQuery] = useState("");
   const [favorites, setFavorites] = useState<string[]>([]);
   const [showFavorites, setShowFavorites] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PROJECTS_PER_PAGE);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
      const storedFavorites = localStorage.getItem("favoriteProjects");
@@ -19,6 +24,11 @@ export default function ProjectGrid() {
        setFavorites(JSON.parse(storedFavorites));
      }
   }, []);
+
+  // Reset visible count when filters change
+  useEffect(() => {
+    setVisibleCount(PROJECTS_PER_PAGE);
+  }, [searchQuery, showFavorites]);
 
   const toggleFavorite = (projectName: string) => {
      let updatedFavorites: string[];
@@ -58,6 +68,32 @@ export default function ProjectGrid() {
     });  
   }, [searchQuery, favorites, showFavorites]);
 
+  const visibleProjects = filteredProjects.slice(0, visibleCount);
+  const hasMore = filteredProjects.length > visibleCount;
+
+  const handleLoadMore = () => {
+    setIsLoadingMore(true);
+    // Small delay for visual feedback, then reveal next batch
+    setTimeout(() => {
+      setVisibleCount((prev) => prev + PROJECTS_PER_PAGE);
+      setIsLoadingMore(false);
+    }, 400);
+  };
+
+  const cardVariants = {
+    hidden: { opacity: 0, y: 28, scale: 0.97 },
+    visible: (i: number) => ({
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: {
+        duration: 0.38,
+        delay: i * 0.06,
+        ease: [0.215, 0.61, 0.355, 1],
+      },
+    }),
+  };
+
   return (
     <div className="mt-15">
       <SearchBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
@@ -79,120 +115,239 @@ export default function ProjectGrid() {
         </div>
 
       {filteredProjects.length > 0 ? (
-        <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredProjects.map((item, index) => (
-            <div
-              key={index}
-              className="group relative overflow-hidden rounded-2xl border border-border backdrop-blur-xl transition-all duration-500 hover:-translate-y-2 hover:shadow-2xl hover:shadow-primary/10"
-            >
-              <div className="relative aspect-video overflow-hidden">
-                <Image
-                  src={`/projects/${item.projectImage}`}
-                  alt={item.projectName}
-                  fill
-                  className="object-cover transition-transform duration-700 ease-out group-hover:scale-110"
-                  sizes="(max-width: 640px) 100vw,
-                         (max-width: 1024px) 50vw,
-                         33vw"
-                  priority={index === 0}
-                />
-                <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-                <button
-                  onClick={() => toggleFavorite(item.projectName)}
-  aria-pressed={favorites.includes(item.projectName)}
-  aria-label={
-    favorites.includes(item.projectName)
-      ? `Remove ${item.projectName} from favorites`
-      : `Add ${item.projectName} to favorites`
-  }
-                  className={`absolute top-3 right-3 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/40 backdrop-blur-md transition-all duration-300 hover:scale-110 hover:bg-black/60 ${
-                    favorites.includes(item.projectName)
-                      ? "text-yellow-400"
-                      : "text-white/70"
-                  }`}
+        <>
+          <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
+            <AnimatePresence mode="popLayout">
+              {visibleProjects.map((item, index) => (
+                <motion.div
+                  key={item.projectName}
+                  custom={index % PROJECTS_PER_PAGE}
+                  variants={cardVariants}
+                  initial="hidden"
+                  animate="visible"
+                  exit={{ opacity: 0, scale: 0.95, transition: { duration: 0.2 } }}
+                  layout
+                  className="group relative overflow-hidden rounded-2xl border border-border backdrop-blur-xl transition-all duration-500 hover:-translate-y-2 hover:shadow-2xl hover:shadow-primary/10"
                 >
-                  <FaBookmark aria-hidden="true" />
-                </button>
-              </div>
-
-              <div className="relative flex flex-col gap-4 p-6">
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="text-lg font-semibold tracking-tight text-start">
-                    {item.projectName}
-                  </h3>
-
-                  <span
-                   aria-label={`Difficulty level: ${item.difficulty}`}
-  className={`rounded-full border px-3 py-1 text-xs font-medium whitespace-nowrap ${
-                     item.difficulty === "Beginner"
-                        ? "border-green-500/30 bg-green-500/10 text-green-400"
-                        : item.difficulty === "Intermediate"
-                        ? "border-yellow-500/30 bg-yellow-500/10 text-yellow-400"
-                        : "border-red-500/30 bg-red-500/10 text-red-400"
-                    }`}
-                  >
-                    {item.difficulty}
-                  </span>
-                </div>  
-
-                <p className="mt-2 text-sm leading-relaxed text-foreground/70 font-medium text-start line-clamp-2">
-                  {item.description}
-                </p>
-
-                {item.techStack && (
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {item.techStack.map((tech: string, i: number) => (
-                      <span
-                        key={i}
-                        className="rounded-full border border-border bg-muted px-2.5 py-0.5 text-xs text-muted-foreground"
-                      >
-                        {tech}
-                      </span>
-                    ))}
+                  <div className="relative aspect-video overflow-hidden">
+                    <Image
+                      src={`/projects/${item.projectImage}`}
+                      alt={item.projectName}
+                      fill
+                      className="object-cover transition-transform duration-700 ease-out group-hover:scale-110"
+                      sizes="(max-width: 640px) 100vw,
+                             (max-width: 1024px) 50vw,
+                             33vw"
+                      priority={index === 0}
+                    />
+                    <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+                    <button
+                      onClick={() => toggleFavorite(item.projectName)}
+                      aria-pressed={favorites.includes(item.projectName)}
+                      aria-label={
+                        favorites.includes(item.projectName)
+                          ? `Remove ${item.projectName} from favorites`
+                          : `Add ${item.projectName} to favorites`
+                      }
+                      className={`absolute top-3 right-3 z-10 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/40 backdrop-blur-md transition-all duration-300 hover:scale-110 hover:bg-black/60 ${
+                        favorites.includes(item.projectName)
+                          ? "text-yellow-400"
+                          : "text-white/70"
+                      }`}
+                    >
+                      <FaBookmark aria-hidden="true" />
+                    </button>
                   </div>
-                )}
 
-                <div className="mt-5 flex items-center gap-3">
-                  {item.liveLink && (
-                    <Link
-                      href={item.liveLink}
-                      target="_blank"
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-muted"
-                    >
-                      <FaLink aria-hidden="true" size={16} />
-                    </Link>
-                  )}
+                  <div className="relative flex flex-col gap-4 p-6">
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-lg font-semibold tracking-tight text-start">
+                        {item.projectName}
+                      </h3>
 
-                  {item.githubLink && (
-                    <Link
-                      href={item.githubLink}
-                      target="_blank"
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-muted"
-                    >
-                      <FaGithub aria-hidden="true" size={16} />
-                    </Link>
-                  )}
+                      <span
+                       aria-label={`Difficulty level: ${item.difficulty}`}
+                        className={`rounded-full border px-3 py-1 text-xs font-medium whitespace-nowrap ${
+                         item.difficulty === "Beginner"
+                            ? "border-green-500/30 bg-green-500/10 text-green-400"
+                            : item.difficulty === "Intermediate"
+                            ? "border-yellow-500/30 bg-yellow-500/10 text-yellow-400"
+                            : "border-red-500/30 bg-red-500/10 text-red-400"
+                          }`}
+                      >
+                        {item.difficulty}
+                      </span>
+                    </div>  
 
-                  {item.ytLink && (
-                    <Link
-                      href={item.ytLink}
-                      target="_blank"
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-red-500 hover:text-white"
-                    >
-                      <FaYoutube aria-hidden="true" size={16} />
-                    </Link>
-                  )}
-                </div>
+                    <p className="mt-2 text-sm leading-relaxed text-foreground/70 font-medium text-start line-clamp-2">
+                      {item.description}
+                    </p>
+
+                    {item.techStack && (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {item.techStack.map((tech: string, i: number) => (
+                          <span
+                            key={i}
+                            className="rounded-full border border-border bg-muted px-2.5 py-0.5 text-xs text-muted-foreground"
+                          >
+                            {tech}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="mt-5 flex items-center gap-3">
+                      {item.liveLink && (
+                        <Link
+                          href={item.liveLink}
+                          target="_blank"
+                          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-muted"
+                        >
+                          <FaLink aria-hidden="true" size={16} />
+                        </Link>
+                      )}
+
+                      {item.githubLink && (
+                        <Link
+                          href={item.githubLink}
+                          target="_blank"
+                          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-muted"
+                        >
+                          <FaGithub aria-hidden="true" size={16} />
+                        </Link>
+                      )}
+
+                      {item.ytLink && (
+                        <Link
+                          href={item.ytLink}
+                          target="_blank"
+                          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background transition-all duration-300 hover:scale-110 hover:bg-red-500 hover:text-white"
+                        >
+                          <FaYoutube aria-hidden="true" size={16} />
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
+
+          {/* Load More Section */}
+          {hasMore && (
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, ease: "easeOut" }}
+              className="mt-12 flex flex-col items-center gap-3"
+            >
+              {/* Progress indicator */}
+              <p className="text-sm text-muted-foreground">
+                Showing{" "}
+                <span className="font-semibold text-foreground">
+                  {visibleProjects.length}
+                </span>{" "}
+                of{" "}
+                <span className="font-semibold text-foreground">
+                  {filteredProjects.length}
+                </span>{" "}
+                projects
+              </p>
+
+              {/* Thin progress bar */}
+              <div className="relative w-48 h-1 rounded-full bg-border overflow-hidden">
+                <motion.div
+                  className="absolute inset-y-0 left-0 rounded-full bg-primary"
+                  initial={{ width: 0 }}
+                  animate={{
+                    width: `${(visibleProjects.length / filteredProjects.length) * 100}%`,
+                  }}
+                  transition={{ duration: 0.5, ease: "easeOut" }}
+                />
               </div>
-            </div>
-          ))}
-        </div>
+
+              {/* Load More Button */}
+              <motion.button
+                id="load-more-projects-btn"
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+                whileHover={{ scale: isLoadingMore ? 1 : 1.04 }}
+                whileTap={{ scale: isLoadingMore ? 1 : 0.97 }}
+                aria-label="Load more projects"
+                className={`
+                  group relative mt-2 flex items-center gap-2.5
+                  rounded-full border border-primary/40
+                  bg-primary/10 px-8 py-3
+                  text-sm font-semibold text-primary
+                  backdrop-blur-md
+                  shadow-[0_0_20px_-4px] shadow-primary/30
+                  transition-all duration-300
+                  hover:bg-primary/20 hover:border-primary/60
+                  hover:shadow-[0_0_28px_-4px] hover:shadow-primary/50
+                  disabled:cursor-not-allowed disabled:opacity-60
+                  focus:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                `}
+              >
+                {isLoadingMore ? (
+                  <>
+                    <svg
+                      className="h-4 w-4 animate-spin"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                      />
+                    </svg>
+                    Loading…
+                  </>
+                ) : (
+                  <>
+                    Load More Projects
+                    <FaChevronDown
+                      aria-hidden="true"
+                      className="h-3 w-3 transition-transform duration-300 group-hover:translate-y-0.5"
+                    />
+                  </>
+                )}
+              </motion.button>
+            </motion.div>
+          )}
+
+          {/* All loaded indicator */}
+          {!hasMore && filteredProjects.length > PROJECTS_PER_PAGE && (
+            <motion.p
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.5 }}
+              className="mt-10 text-center text-sm text-muted-foreground"
+            >
+              ✓ All{" "}
+              <span className="font-semibold text-foreground">
+                {filteredProjects.length}
+              </span>{" "}
+              projects loaded
+            </motion.p>
+          )}
+        </>
       ) : (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <FaSearch
-  aria-hidden="true"
-  className="mb-4 text-4xl text-foreground/50"
-/>
+            aria-hidden="true"
+            className="mb-4 text-4xl text-foreground/50"
+          />
           <h3 className="text-lg font-semibold">
             {projectConfig.notFound.title}
           </h3>


### PR DESCRIPTION
##  feat: Add "Load More" Pagination to Projects Grid

###  Related Issue
Closes #[81] — *Add Pagination / Load More Button to Projects Page*

---

###  Problem
As the repository grows toward 100+ projects, rendering all cards at once causes performance issues and creates an overwhelming, endlessly scrolling experience for users.

---

### Solution
Implemented a **"Load More"** button that loads projects in batches of 6, giving users control over how much they browse — without the unpredictability of infinite scroll.

---

### Changes Made

**`components/project/project-grid.tsx`**

-  Shows **6 projects initially** (`PROJECTS_PER_PAGE` constant — easy to adjust)
- **"Load More Projects"** button appends the next batch on click
- **Smooth staggered fade + slide-up animation** on newly loaded cards via `framer-motion` (`AnimatePresence`)
-  **Animated progress bar** showing how many projects are visible vs. total
- **Spinner loading state** (400ms) while next batch is revealed
- **Auto-resets pagination** when search query or Favorites filter changes
-  **"All X projects loaded"** confirmation message when fully paginated
- **Accessible**: `aria-label`, `focus-visible` ring, `disabled` state, unique `id` on button

---

###  UI / Theme Match

The button is styled to **match the existing dark theme** exactly:
- `rounded-full` pill shape consistent with the site's design language
- Teal/primary glow (`shadow-primary`) — uses the same CSS custom property as other interactive elements
- `bg-primary/10` glassmorphic background with `backdrop-blur`
- `border-primary/40` border with hover intensification
- `framer-motion` `whileHover` / `whileTap` scale micro-interactions

---
###  Testing Done

- [x] Projects load in batches of 6 on initial render
- [x] "Load More" appends next 6 with animation
- [x] Progress bar updates on each load
- [x] Searching resets back to first page automatically
- [x] Toggling Favorites resets back to first page automatically
- [x] "All X projects loaded" message appears at the end
- [x] No TypeScript errors

---

###  Type of Change

- [x] New feature (non-breaking)
- [ ]  Bug fix
- [ ]  Breaking change
- [ ]  Documentation update

---

