### PR TITLE
feat: add CI workflow for linting and build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v3
+      with:
+        version: 9
+        run_install: false
+        
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+          
+    - name: Install dependencies
+      run: pnpm install --no-frozen-lockfile
+      
+    - name: Run linter
+      run: pnpm lint
+      
+    - name: Build project
+      run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
           
     - name: Install dependencies
-      run: pnpm install --no-frozen-lockfile
+      run: pnpm install --frozen-lockfile
       
     - name: Run linter
       run: pnpm lint


### PR DESCRIPTION
Closes #97

## Description
Adds a GitHub Actions CI workflow that automatically runs linting and build checks on every push and pull request to the main branch.

## Changes
- .github/workflows/ci.yml — New workflow with Node 20 + pnpm setup, caching, lint and build steps

## Key Details
- Uses \pnpm install --frozen-lockfile\ for reproducible installs
- Runs \pnpm lint\ and \pnpm build\ to catch errors early
- Caches pnpm store for faster subsequent runs
- Triggers on push and pull_request to main branch

## Testing
- Workflow verified to pass on this PR (all checks green)