### PR TITLE
feat: add smooth animation for mobile navbar menu

### DIFF
--- a/components/common/nav-menu.tsx
+++ b/components/common/nav-menu.tsx
@@ -12,16 +12,20 @@ interface NavMenu {
 export default function NavMenu({ open, setOpen }: NavMenu) {
   const pathname = usePathname();
 
-  if (!open) return null;
 
   return (
     <ul
       id="mobile-menu"
       aria-label="Mobile navigation menu"
-      className="absolute top-full left-1/2 w-full max-w-sm
-      -translate-x-1/2 rounded-b-2xl border border-border
-      bg-background/95 backdrop-blur-md shadow-lg
-      md:hidden flex flex-col items-start justify-center gap-2 p-4"
+      className={`absolute top-full left-1/2 w-full max-w-sm
+-translate-x-1/2 rounded-b-2xl border border-border
+bg-background/95 backdrop-blur-md shadow-lg overflow-hidden
+md:hidden flex flex-col items-start gap-2 px-4
+transition-all duration-300 ease-in-out origin-top
+${open
+          ? "max-h-96 opacity-100 py-4 translate-y-0"
+          : "max-h-0 opacity-0 py-0 -translate-y-3 pointer-events-none border-transparent"
+        }`}
     >
       {navbarConfig.items.map((item) => {
         const isActive = pathname === item.href;

--- a/components/common/navbar.tsx
+++ b/components/common/navbar.tsx
@@ -15,7 +15,7 @@ export default function Navbar() {
   return (
     <nav
       className={`fixed top-4 left-1/2 z-50 w-[95%] max-w-6xl -translate-x-1/2
-      flex items-center justify-between
+      flex items-center justify-between transition-all duration-300 ease-out
       ${open ? "rounded-t-2xl" : "rounded-2xl"} md:rounded-2xl border border-border
       backdrop-blur-md
       px-6 py-3 shadow-lg`}


### PR DESCRIPTION
Description:
This PR adds a smooth animation to the mobile navbar  menu when opening and closing it.


Closes #126 

Before

https://github.com/user-attachments/assets/54689781-9580-4413-ab2d-8d8a219c702f

After


https://github.com/user-attachments/assets/dc9a7ba2-8f9a-4749-a5d3-6f8e121d1fd7



AI Usage: AI Used to write commit message.



