### PR TITLE
fix(webhook): remove invalid second argument from revalidateTag

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
     return Response.json({ ok: true, ignored: true, event });
   }
 
-  revalidateTag(DASHBOARD_CACHE_TAG, "max");
+  revalidateTag(DASHBOARD_CACHE_TAG);
   revalidatePath("/dashboard");
 
   return Response.json({ ok: true, revalidated: true, event });


### PR DESCRIPTION
### Purpose of this PR
This PR resolves a critical build issue where the `revalidateTag()` function was being called with an extra argument inside the GitHub webhook route, causing compilation failures.

### Changes Made
- Modified `app/api/github/webhook/route.ts` on line 64.
- Removed the invalid second argument `"max"` from `revalidateTag(DASHBOARD_CACHE_TAG, "max")` to follow with Next.js single-argument specifications.

### Closes
Closes #154