### PR TITLE
Pr autolabel pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Linked issues
+
+<!--
+Use one line per issue.
+Examples:
+Closes #76
+Fixes #120
+Resolves #145
+-->
+
+Closes #<issue-number>
+
+## Summary
+
+Replace this text with a brief summary.
+
+## Changes made
+
+- Replace this item with the concrete changes in this PR.
+
+## How to test
+
+- Replace this item with exact verification steps.
+
+## Screenshots or recordings
+
+Replace this text with screenshot links, a recording, or N/A.
+
+## Checklist
+
+- [ ] I tested these changes locally.
+- [ ] I kept this PR focused and avoided unrelated changes.
+- [ ] I added screenshots or recordings for UI changes, or this PR does not change the UI.
+
+## AI disclosure
+
+Replace this text with None or a short disclosure.

--- a/.github/workflows/sync-pr-issue-labels.yml
+++ b/.github/workflows/sync-pr-issue-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Sync linked issue labels or clean up unmerged pull requests

--- a/.github/workflows/sync-pr-issue-labels.yml
+++ b/.github/workflows/sync-pr-issue-labels.yml
@@ -1,0 +1,155 @@
+name: Sync linked issue labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review, closed]
+
+jobs:
+  sync-linked-issue-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Sync linked issue labels or clean up unmerged pull requests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const action = context.payload.action;
+            const pullRequest = context.payload.pull_request;
+            const pullRequestNumber = pullRequest.number;
+
+            const escapeRegex = (value) =>
+              value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            const getSection = (content, heading) => {
+              const escapedHeading = escapeRegex(heading);
+              const regex = new RegExp(
+                `## ${escapedHeading}\\r?\\n([\\s\\S]*?)(?=\\r?\\n## |$)`,
+                'i'
+              );
+              const match = content.match(regex);
+
+              return match ? match[1].trim() : '';
+            };
+
+            if (action === 'closed' && !pullRequest.merged) {
+              await github.rest.issues.removeAllLabels({
+                owner,
+                repo,
+                issue_number: pullRequestNumber
+              });
+
+              console.log(
+                `Removed all labels from unmerged pull request #${pullRequestNumber}.`
+              );
+              return;
+            }
+
+            if (action === 'closed' && pullRequest.merged) {
+              console.log(`Pull request #${pullRequestNumber} was merged. Keeping its labels.`);
+              return;
+            }
+
+            const linkedIssuesSection = getSection(pullRequest.body || '', 'Linked issues');
+            const sourceText = linkedIssuesSection || [pullRequest.title, pullRequest.body]
+              .filter(Boolean)
+              .join('\n');
+
+            const sameRepoPath = escapeRegex(`${owner}/${repo}`);
+            const closingIssuePattern = new RegExp(
+              `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s*(?:https?:\\/\\/github\\.com\\/${sameRepoPath}\\/issues\\/|${sameRepoPath}#|#)(\\d+)`,
+              'gi'
+            );
+
+            const issueNumbers = [
+              ...new Set(
+                [...sourceText.matchAll(closingIssuePattern)]
+                  .map((match) => Number(match[1]))
+                  .filter((issueNumber) => Number.isInteger(issueNumber))
+              )
+            ];
+
+            if (!issueNumbers.length) {
+              console.log('No linked issue found in the pull request body. Skipping label sync.');
+              return;
+            }
+
+            const pullRequestIssue = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: pullRequestNumber
+            });
+
+            const existingPullRequestLabels = new Set(
+              (pullRequestIssue.data.labels || []).map((label) => label.name.toLowerCase())
+            );
+            const syncedLabelsByName = new Map();
+
+            for (const issueNumber of issueNumbers) {
+              let issueResponse;
+
+              try {
+                issueResponse = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`Issue #${issueNumber} was not found. Skipping it.`);
+                  continue;
+                }
+
+                throw error;
+              }
+
+              if (issueResponse.data.pull_request) {
+                console.log(`#${issueNumber} is a pull request, not an issue. Skipping it.`);
+                continue;
+              }
+
+              for (const label of issueResponse.data.labels || []) {
+                const labelName = typeof label === 'string' ? label : label.name;
+
+                if (!labelName) {
+                  continue;
+                }
+
+                syncedLabelsByName.set(labelName.toLowerCase(), labelName);
+              }
+            }
+
+            const labelsToSync = [...syncedLabelsByName.values()];
+
+            if (!labelsToSync.length) {
+              console.log(
+                `No labels were found on the linked issues for pull request #${pullRequestNumber}.`
+              );
+              return;
+            }
+
+            const missingLabels = labelsToSync.filter(
+              (labelName) => !existingPullRequestLabels.has(labelName.toLowerCase())
+            );
+
+            if (!missingLabels.length) {
+              console.log(
+                `Pull request #${pullRequestNumber} already has every label from its linked issues.`
+              );
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pullRequestNumber,
+              labels: missingLabels
+            });
+
+            console.log(
+              `Added labels to PR #${pullRequestNumber} from linked issues ${issueNumbers.join(', ')}: ${missingLabels.join(', ')}`
+            );

--- a/.github/workflows/validate-pr-template.yml
+++ b/.github/workflows/validate-pr-template.yml
@@ -1,0 +1,120 @@
+name: Validate pull request template
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+
+jobs:
+  validate-pr-template:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Validate the required pull request template fields
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullRequest = context.payload.pull_request;
+            const body = pullRequest.body || '';
+
+            const escapeRegex = (value) =>
+              value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            const stripHtmlComments = (value) =>
+              value.replace(/<!--[\s\S]*?-->/g, '').trim();
+
+            const getSection = (content, heading) => {
+              const escapedHeading = escapeRegex(heading);
+              const regex = new RegExp(
+                `## ${escapedHeading}\\r?\\n([\\s\\S]*?)(?=\\r?\\n## |$)`,
+                'i'
+              );
+              const match = content.match(regex);
+
+              return match ? match[1].trim() : '';
+            };
+
+            const hasMeaningfulContent = (value) => {
+              const placeholderLines = new Set([
+                'Replace this text with a brief summary.',
+                '- Replace this item with the concrete changes in this PR.',
+                'Replace this item with the concrete changes in this PR.',
+                '- Replace this item with exact verification steps.',
+                'Replace this item with exact verification steps.',
+                'Replace this text with screenshot links, a recording, or N/A.',
+                'Replace this text with None or a short disclosure.'
+              ]);
+
+              const meaningfulLines = stripHtmlComments(value)
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter((line) => line && line !== '-' && !placeholderLines.has(line));
+
+              return meaningfulLines.length > 0;
+            };
+
+            const isCheckboxChecked = (content, labelText) => {
+              const escapedLabel = escapeRegex(labelText);
+              const regex = new RegExp(`- \\[x\\] ${escapedLabel}`, 'i');
+
+              return regex.test(content);
+            };
+
+            const sameRepoPath = escapeRegex(`${owner}/${repo}`);
+            const closingIssuePattern = new RegExp(
+              `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s*:?\\s*(?:https?:\\/\\/github\\.com\\/${sameRepoPath}\\/issues\\/|${sameRepoPath}#|#)(\\d+)`,
+              'gi'
+            );
+
+            const linkedIssues = stripHtmlComments(getSection(body, 'Linked issues'));
+            const summary = getSection(body, 'Summary');
+            const changesMade = getSection(body, 'Changes made');
+            const howToTest = getSection(body, 'How to test');
+            const screenshots = stripHtmlComments(getSection(body, 'Screenshots or recordings'));
+            const aiDisclosure = stripHtmlComments(getSection(body, 'AI disclosure'));
+            const linkedIssueMatches = [...linkedIssues.matchAll(closingIssuePattern)];
+
+            const failures = [];
+
+            if (!linkedIssueMatches.length) {
+              failures.push(
+                '`## Linked issues` must contain at least one valid closing keyword such as `Closes #76`.'
+              );
+            }
+
+            if (!hasMeaningfulContent(summary)) {
+              failures.push('`## Summary` must explain what changed and why.');
+            }
+
+            if (!hasMeaningfulContent(changesMade)) {
+              failures.push('`## Changes made` must list the concrete updates in the PR.');
+            }
+
+            if (!hasMeaningfulContent(howToTest)) {
+              failures.push('`## How to test` must include reviewer-facing verification steps.');
+            }
+
+            if (!hasMeaningfulContent(screenshots)) {
+              failures.push(
+                '`## Screenshots or recordings` must contain screenshots, a recording, or `N/A`.'
+              );
+            }
+
+            if (!hasMeaningfulContent(aiDisclosure)) {
+              failures.push('`## AI disclosure` must contain `None` or a brief disclosure note.');
+            }
+
+            if (!isCheckboxChecked(body, 'I tested these changes locally.')) {
+              failures.push('The local-testing checkbox must be checked.');
+            }
+
+            if (!isCheckboxChecked(body, 'I kept this PR focused and avoided unrelated changes.')) {
+              failures.push('The focused-PR checkbox must be checked.');
+            }
+
+            if (failures.length) {
+              throw new Error(`PR template validation failed:\n- ${failures.join('\n- ')}`);
+            }


### PR DESCRIPTION
- added [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) so contributors must fill a structured PR template with linked issues, summary, testing steps, screenshots, and ai disclosure.
- added [.github/workflows/validate-pr-template.yml](.github/workflows/validate-pr-template.yml) which checks if PR is done right or not. (according to the PR template)
- added [sync-pr-issue-labels.yml](.github/workflows/sync-pr-issue-labels.yml) the label-sync logic so it reads every closing issue reference in the PR and copies the union of all issue labels to the PR
- added cleanup logic so every label is removed when a PR is closed without being merged

## Screenshots or recordings

<img width="1654" height="2370" alt="github com_ARPANPATRA111_GSSOC_100-reactjs-projects_pull_18 (1)" src="https://github.com/user-attachments/assets/c2bd29a0-eb83-41c1-981b-fee5cb4110ea" />


## what will this workflow do ?
1. It checks whether contributors actually followed the PR template.
2. It copies all labels from every linked closing issue to the PR.
3. It removes all labels from a PR if that PR is closed without merge.

## Known limitations

- if issue labels change after the PR has already been labelled, the PR will **not** automatically resync until the PR is edited or another tracked PR event happens
- if linked issues are changed later, previously synced labels are not automatically removed unless the PR is closed without merge
- if maintainers use issue labels that they do not want copied to PRs, this workflow will still copy them because it now mirrors every issue label

Closes #76