### PR TITLE
fix: use lazy state initializer for isMobile to avoid setState in effect

### DIFF
--- a/hooks/use-mobile.ts
+++ b/hooks/use-mobile.ts
@@ -3,8 +3,8 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
+  const [isMobile, setIsMobile] = React.useState<boolean>(
+    typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT,
   );
 
   React.useEffect(() => {
@@ -13,7 +13,6 @@ export function useIsMobile() {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener("change", onChange);
   }, []);
 


### PR DESCRIPTION
Uses a lazy initializer for the isMobile state to set the initial value based on the window width, instead of calling setState synchronously within a useEffect.