### PR TITLE
fix: remove invalid argument from revalidateTag and wrap JSON.parse in try-catch

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
     return Response.json({ ok: true, ignored: true, event });
   }
 
-  revalidateTag(DASHBOARD_CACHE_TAG, "max");
+  revalidateTag(DASHBOARD_CACHE_TAG);
   revalidatePath("/dashboard");
 
   return Response.json({ ok: true, revalidated: true, event });

--- a/components/project/project-grid.tsx
+++ b/components/project/project-grid.tsx
@@ -26,10 +26,14 @@ export default function ProjectGrid() {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
-    const storedFavorites = localStorage.getItem("favoriteProjects");
+    try {
+      const storedFavorites = localStorage.getItem("favoriteProjects");
 
-    if (storedFavorites) {
-      setFavorites(JSON.parse(storedFavorites));
+      if (storedFavorites) {
+        setFavorites(JSON.parse(storedFavorites));
+      }
+    } catch {
+      // Ignore corrupted localStorage data
     }
   }, []);
 


### PR DESCRIPTION
**Fixes**:

1. **`app/api/github/webhook/route.ts`**: Removed invalid second argument "max" from `revalidateTag()` call. `revalidateTag` only accepts a single cache tag string.

2. **`components/project/project-grid.tsx`**: Wrapped `JSON.parse(storedFavorites)` in a try-catch block. If localStorage has corrupted data, the entire component would crash previously.