### PR TITLE
fix: resolve circular dependency between projects.tsx and project-Item.tsx

### DIFF
--- a/config/project-Item.tsx
+++ b/config/project-Item.tsx
@@ -1,4 +1,13 @@
-import { ProjectItems } from "./projects";
+export interface ProjectItems {
+  projectName: string;
+  description: string;
+  projectImage: string;
+  githubLink: string;
+  liveLink?: string;
+  ytLink?: string;
+  techStack: string[];
+  difficulty: string;
+}
 
 export const projectItemConfig: ProjectItems[] = [
   {

--- a/config/projects.tsx
+++ b/config/projects.tsx
@@ -1,15 +1,4 @@
-import { projectItemConfig } from "./project-Item";
-
-export interface ProjectItems {
-  projectName: string;
-  description: string;
-  projectImage: string;
-  githubLink: string;
-  liveLink?: string;
-  ytLink?: string;
-  techStack: string[];
-  difficulty: string;
-}
+import { ProjectItems, projectItemConfig } from "./project-Item";
 
 interface Project {
   description: string;


### PR DESCRIPTION
Fixed circular import: project-Item.tsx imported ProjectItems type from projects.tsx, while projects.tsx imported projectItemConfig from project-Item.tsx. Moved ProjectItems interface definition into project-Item.tsx and re-exported from projects.tsx.