### PR TITLE
BATCH-4: Fix invalid revalidateTag argument in webhook route

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
     return Response.json({ ok: true, ignored: true, event });
   }
 
-  revalidateTag(DASHBOARD_CACHE_TAG, "max");
+  revalidateTag(DASHBOARD_CACHE_TAG);
   revalidatePath("/dashboard");
 
   return Response.json({ ok: true, revalidated: true, event });


### PR DESCRIPTION
**Bug:** `revalidateTag(DASHBOARD_CACHE_TAG, "max")` in the GitHub webhook route passes an invalid second argument. `revalidateTag` from `next/cache` only accepts a single tag string. This would throw a runtime TypeError when the webhook is triggered.

**Fix:** Removed the extraneous `"max"` second argument.