### PR TITLE
fix: break circular dependency between config/projects.tsx and config/project-Item.tsx

### DIFF
--- a/config/project-Item.tsx
+++ b/config/project-Item.tsx
@@ -1,4 +1,4 @@
-import { ProjectItems } from "./projects";
+import { ProjectItems } from "@/types/project-items";
 
 export const projectItemConfig: ProjectItems[] = [
   {

--- a/config/projects.tsx
+++ b/config/projects.tsx
@@ -1,15 +1,4 @@
-import { projectItemConfig } from "./project-Item";
-
-export interface ProjectItems {
-  projectName: string;
-  description: string;
-  projectImage: string;
-  githubLink: string;
-  liveLink?: string;
-  ytLink?: string;
-  techStack: string[];
-  difficulty: string;
-}
+import { projectItemConfig, ProjectItems } from "./project-Item";
 
 interface Project {
   description: string;

--- a/types/project-items.ts
+++ b/types/project-items.ts
@@ -1,0 +1,10 @@
+export interface ProjectItems {
+  projectName: string;
+  description: string;
+  projectImage: string;
+  githubLink: string;
+  liveLink?: string;
+  ytLink?: string;
+  techStack: string[];
+  difficulty: string;
+}


### PR DESCRIPTION
Extract shared `ProjectItems` interface into `types/project-items.ts` to resolve the circular import dependency between `config/projects.tsx` and `config/project-Item.tsx`. Both config files now import `ProjectItems` from the new types file.

- `projects.tsx` re-exports `ProjectItems` from `./project-Item`
- `project-Item.tsx` imports `ProjectItems` from `@/types/project-items`